### PR TITLE
use trait byteorder so that we can avoid doing manual byte conversions for vec<u8> to respective types (2 bytes, 4 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "img_bmp"
 version = "0.1.0"
+dependencies = [
+ "byteorder",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+byteorder = "1.5.0"

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -6,7 +6,7 @@ use std::{
 
 pub struct BMPFileHeader {
     // (2 bytes) signature of the bmp file
-    pub signature: Vec<u8>,
+    pub signature: u16,
     // (4 bytes) size of the bmp file
     // size: u32,
     // (2 bytes) reserved byte 1 for the spec
@@ -55,15 +55,18 @@ impl BMPFile {
 
         // first we get the signature bits in header and
         // validate that the signature is correct
-        let mut bmp_signature: Vec<u8> = vec![0; 2];
-        bmp_file.read_exact(&mut bmp_signature)?;
+        let mut bmp_signature_bytes: Vec<u8> = vec![0; 2];
+        bmp_file.read_exact(&mut bmp_signature_bytes)?;
 
-        if !BMPFile::validate_header_signature(&bmp_signature) {
+        if !BMPFile::validate_header_signature(&bmp_signature_bytes) {
             panic!(
                 "{:?} is an invalid BMP file due to invalid BMP signature: [{:#x}, {:#x}]",
-                bmp_filepath, bmp_signature[0], bmp_signature[1]
+                bmp_filepath, bmp_signature_bytes[0], bmp_signature_bytes[1]
             );
         }
+
+        let bmp_signature: u16 =
+            ((bmp_signature_bytes[0] as u16) << 8) | bmp_signature_bytes[1] as u16;
 
         Ok(Self {
             header: BMPFileHeader {

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -1,6 +1,7 @@
+use byteorder::{BigEndian, ReadBytesExt};
 use std::{
     fs::File,
-    io::{Error, Read},
+    io::{Cursor, Error, Read},
 };
 // ref for BMP spec: https://upload.wikimedia.org/wikipedia/commons/7/75/BMPfileFormat.svg
 
@@ -65,8 +66,9 @@ impl BMPFile {
             );
         }
 
-        let bmp_signature: u16 =
-            ((bmp_signature_bytes[0] as u16) << 8) | bmp_signature_bytes[1] as u16;
+        let mut bmp_signature_cursor = Cursor::new(&bmp_signature_bytes);
+
+        let bmp_signature: u16 = bmp_signature_cursor.read_u16::<BigEndian>()?;
 
         Ok(Self {
             header: BMPFileHeader {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,7 @@ fn main() -> Result<(), Error> {
 
     match maybe_bmp {
         Ok(bmp) => {
-            println!(
-                "signature: [{:#x}, {:#x}]",
-                bmp.header.signature[0], bmp.header.signature[1]
-            );
+            println!("signature: {:#x}", bmp.header.signature);
         }
         Err(error) => panic!("{:?}", error),
     }


### PR DESCRIPTION
use trait byteorder so that we can avoid doing manual byte conversions for vec<u8> to respective types (2 bytes, 4 bytes etc)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/kanhegaonkarsaurabh/bmp_parser_rs/pull/2).
* __->__ #2
* #1